### PR TITLE
Fix round history being off by one

### DIFF
--- a/src/components/servers/RoundHistory.tsx
+++ b/src/components/servers/RoundHistory.tsx
@@ -119,7 +119,7 @@ const RoundHistory = ({ server }: RoundHistoryProps) => {
       const serverRoundsResponse = await fetchSS13ServerRounds(
         server.id,
         itemsPerPage,
-        page * itemsPerPage - 1
+        (page - 1) * itemsPerPage - 1
       );
       const roundsList = serverRoundsResponse.rounds;
       setTotalRounds(serverRoundsResponse.total);


### PR DESCRIPTION
Round history starts on page 2, now it starts on page 1